### PR TITLE
skip flakey test

### DIFF
--- a/test_cases/widget_form_save.js
+++ b/test_cases/widget_form_save.js
@@ -226,7 +226,7 @@ export default () => {
          // cy.get(".trash").click();
          // cy.get(".webix_popup_button.confirm").should("be.visible").click();
       });
-      it("conditional record rules - greater than 1", () => {
+      it.skip("conditional record rules - greater than 1", () => {
          cy.get(
             '[data-cy="tab-Menu-773dca98-87e0-4dc2-b528-89ec7c98c448-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]'
          ).click();


### PR DESCRIPTION
This test is failing often in our github workflow test environments. But re-running the tests it usually passes, so it's not actually a problem with the code, but with the test.

Skip it until we can make it more stable. Maybe related to the cy.wait here (which we should see if we can remove it).