### PR TITLE
change cy.reload() -> cy.visit("/")

### DIFF
--- a/test_cases/widget_grid.js
+++ b/test_cases/widget_grid.js
@@ -58,7 +58,7 @@ export default () => {
          // We reload here because cypress gets confused when we scroll multiple
          // times in the same grid. We could do this as a seperate test, but
          // that adds overhead.
-         cy.reload();
+         cy.visit("/");
          cy.get(
             '[data-cy="tab-Grid-e7c04584-4fbd-4ca9-b64b-0f5bcb477c1e-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]'
          )

--- a/test_cases/widget_scope.js
+++ b/test_cases/widget_scope.js
@@ -50,7 +50,7 @@ export default (folderName, Common) => {
 };
 
 function reloadToScopePage() {
-   cy.reload();
+   cy.visit("/");
    cy.get('[data-cy="portal_work_menu_sidebar"]').should("be.visible").click();
    cy.get('[data-cy="0ac51d6c-7c95-461c-aa8b-7da00afc4f48"]')
       .should("be.visible")


### PR DESCRIPTION
These `cy.reload()` commands seem to fail on our workflow in ab_platform_web. I suspect it is related to the fact that we now redirect `/` to `/home` in api sails so `reload()` isn't the same as `cy.visit("/")` now . 