### PR TITLE
remove check for current comment

### DIFF
--- a/test_cases/widget_comment.js
+++ b/test_cases/widget_comment.js
@@ -140,10 +140,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -175,10 +175,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -208,10 +208,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -245,10 +245,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -278,11 +278,11 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get(".webix_comments")
-            .first()
-            .find(".webix_comments_current")
-            .last()
-            .click({ force: true });
+         // cy.get(".webix_comments")
+         //    .first()
+         //    .find(".webix_comments_current")
+         //    .last()
+         //    .click({ force: true });
 
          // cy.get(".webix_progress_state").should("not.exist");
 
@@ -300,9 +300,10 @@ export default (folderName, Common) => {
             .find(".webix_view.webix_list")
             .children()
             .should("have.length", 1);
+
          cy.get(".webix_comments")
             .first()
-            .find(".webix_comments_current")
+            .find(".webix_list_item")
             .last()
             .find(".webix_comments_menu")
             .click({ force: true });
@@ -332,10 +333,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -382,10 +383,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -430,10 +431,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -470,10 +471,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -511,10 +512,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -552,10 +553,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -594,10 +595,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -622,10 +623,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -669,10 +670,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);
@@ -697,10 +698,10 @@ export default (folderName, Common) => {
 
          pressSendButton();
 
-         cy.get("div")
-            .should("have.class", "webix_list_item webix_comments_current")
-            .contains("admin")
-            .click({ force: true });
+         // cy.get("div")
+         //    .should("have.class", "webix_list_item webix_comments_current")
+         //    .contains("admin")
+         //    .click({ force: true });
 
          // eslint-disable-next-line cypress/no-unnecessary-waiting
          cy.wait(500);


### PR DESCRIPTION
Because we are listening for update events and reloading the comments when create, updates and deletes occur we cannot check for the webix_comments_current class. This only was passing before because of an issue with the test object and new comments were not actually being saved to the database but only added temporarily to the UI. Therefore the listener for the datacollection did not fire and the ui did not rebuild itself with the "new" comment. So it looked good but was actually not working due to this issue and the tests were built around this faulty setup.