### PR TITLE
Refactor comment widget tests

### DIFF
--- a/test_cases/widget_comment.js
+++ b/test_cases/widget_comment.js
@@ -1,772 +1,139 @@
-export default (folderName, Common) => {
+export default (/*folderName*/) => {
    describe("Comment", () => {
       beforeEach(() => {
-         // Common.Reset(cy, folderName);
-         cy.visit("/");
-      }); //End beforeEach
-
-      //1. can find the first comment avatar text "A"
-      it("can find the first A", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
          cy.get(
             '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
          ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("A");
-
-         pressSendButton();
-
-         cy.get(".webix_comments_avatar")
-            .contains("A")
-            .should("have.class", "webix_comments_avatar_image");
-      }); //End 1
-
-      //2. can find the first comment  name "admin"
-      it("can find the first comment  name admin", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("A");
-         pressSendButton();
-
-         cy.get(".webix_list_item")
-            .contains("admin")
-            .should("have.class", "webix_comments_name");
-      }); //End 2
-      //3. can find the first comment date "10 Sep, 00:00"
-      it("can find the first comment date", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("A");
-
-         pressSendButton();
-
-         const months = [
-            "Jan",
-            "Feb",
-            "Mar",
-            "Apr",
-            "May",
-            "Jun",
-            "Jul",
-            "Aug",
-            "Sep",
-            "Oct",
-            "Nov",
-            "Dec",
-         ];
-         var d = new Date();
-
-         // Johnny: OK, when running locally, your server running in a docker
-         // container might be in a different time zone than your local computer
-         // and the days might be off.
-         // What's important here is that we find the date.
-         var datestring =
-            // d.getDate("dd") +
-            // " " +
-            months[d.getMonth("M")] + "," + " " + "00:00";
-         cy.get("span");
-         cy.contains("span", datestring);
-      }); //End 3
-
-      //4. can find the first comment message "test"
-      it("can find the first comment message test", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         cy.get(".webix_list_item")
-            .contains("test")
-            .should("have.class", "webix_comments_message");
-      }); //End 4
-      //5. can find the first comment menu which has icon "wxi-dots"
-      it("can find the first comment menu which has icon wxi-dots", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         cy.get("span")
-            .should("have.class", "wxi-dots")
-            .and("have.class", "webix_icon")
-            .and("have.class", "webix_comments_menu");
-      }); //End 5
-      //6. can find the option icon "wix-pencil"
-      it("can find the option icon wix-pencil", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_list_icon webix_icon wxi-pencil"]')
-            .should("have.class", "webix_list_icon webix_icon wxi-pencil")
-            .and("have.class", "wxi-pencil");
-      }); //End 6
-
-      //7. can find the option text "Edit"
-      it("can find the option text Edit", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').should("contain", "Edit");
-      }); //End 7
-
-      //8. can find the option icon "wxi-trash"
-      it("can find the option icon wxi-trash", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         )
-            .as("wxitrash")
-            .scrollIntoView();
-         cy.get("@wxitrash").should("be.visible").click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_list_icon webix_icon wxi-trash"]')
-            .should("have.class", "webix_list_icon webix_icon wxi-trash")
-            .and("have.class", "wxi-trash");
-      }); //End 8
-
-      //9. can find the option text "Remove"
-      it("can find the option text Remove", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         )
-            .should("be.visible")
-            .click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').should("contain", "Remove");
-      }); //End 9
-
-      //10. can find the text "test" on the first textarea
-      it("can find the text test on the first textarea", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get(".webix_comments")
-         //    .first()
-         //    .find(".webix_comments_current")
-         //    .last()
-         //    .click({ force: true });
-
-         // cy.get(".webix_progress_state").should("not.exist");
-
-         // Sometimes the progress icon is gone too fast.
-         // let's make sure that by counting elements in the grid instead.
          cy.get(
             '[view_id="ABViewComment_2a2db721-5093-44a2-999d-3f4a58420129"]',
          )
-            .find(".webix_view.webix_list")
-            .children()
-            .should("have.length", 1);
+            .as("commentWidget")
+            .find("textArea")
+            .as("input")
+            .click();
+         cy.get("@input").type("hello world!");
+         cy.get("@commentWidget")
+            .find("button")
+            .as("submitButton")
+            .should("exist")
+            .click();
+         cy.get(".webix_progress_state").should("not.exist");
          cy.get(
-            '[view_id="ABViewComment_aac06b2a-7f4e-4daf-9b39-ccd71858e150"]',
-         )
-            .find(".webix_view.webix_list")
-            .children()
-            .should("have.length", 1);
+            '[view_id="ABViewComment_2a2db721-5093-44a2-999d-3f4a58420129"] > .webix_comments > .webix_list > .webix_scroll_cont > .webix_list_item',
+         ).as("theComment");
+      });
 
-         cy.get(".webix_comments")
-            .first()
-            .find(".webix_list_item")
-            .last()
+      it("adds a comment", () => {
+         //1. can find the first comment avatar text "A"
+         cy.get("@theComment")
+            .find(".webix_comments_avatar")
+            .contains("A")
+            .should("have.class", "webix_comments_avatar_image");
+
+         //2. can find the first comment name "admin"
+         cy.get("@theComment")
+            .find(".webix_comments_name")
+            .should("contain", "admin");
+
+         //3. can find the first comment date "10 Sep, 00:00"
+         cy.get("@theComment")
+            .find("span.webix_comments_date")
+            // Note test the date pattern, not that the actual date time is
+            // correct
+            .invoke("text")
+            .should("match", /\d\d? [A-Z][a-z]{2}, \d\d:\d\d/);
+
+         //4. can find the first comment message
+         cy.get("@theComment")
+            .find(".webix_comments_message")
+            .should("contain", "hello world!");
+
+         //5. can find the first comment menu which has icon "wxi-dots"
+         cy.get("@theComment")
+            .find(".webix_comments_menu")
+            .as("commentMenu")
+            .should("have.class", "wxi-dots")
+            .and("have.class", "webix_icon");
+
+         //6. can find the option icon "wix-pencil"
+         //7. can find the option text "Edit"
+         cy.get("@commentMenu").click({ force: true });
+         cy.get(".webix_popup.webix_menu").filter(":visible").as("popUpMenu");
+         cy.get("@popUpMenu")
+            .find('[webix_l_id="edit"]')
+            .should("contain", "Edit")
+            .find("span")
+            .should("have.class", "webix_list_icon webix_icon wxi-pencil");
+
+         //8. can find the option icon "wxi-trash"
+         //9. can find the option text "Remove"
+         cy.get("@popUpMenu")
+            .find('[webix_l_id="remove"]')
+            .should("contain", "Remove")
+            .find("span")
+            .should("have.class", "webix_list_icon webix_icon wxi-trash");
+      });
+
+      //10. can find the text "test" on the first textarea
+      it("edits a comment", () => {
+         cy.get("@theComment")
             .find(".webix_comments_menu")
             .click({ force: true });
-
-         cy.get('a[class="webix_list_item menu"]').eq(0).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(1000);
-
-         cy.get("textarea")
-            .should("have.class", "webix_inp_textarea")
-            .should("have.value", "test");
-      }); //End 10
-
-      //11. can find the text "cypress hahaha" on the first comment
-      it("can find the text cypress hahaha on the first comment", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
+         cy.get('[webix_l_id="edit"]').should("be.visible").click();
          cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
+            '[view_id="ABViewComment_2a2db721-5093-44a2-999d-3f4a58420129"]',
+         ).as("theWidget");
+         //10. can find the text original text in the textarea
+         cy.get("@theWidget")
+            .find("textarea")
+            .as("input")
+            .should("have.value", "hello world!");
+         //11. can find the editted text in the comment
+         //12. should't have found the original text in the comment
+         cy.get("@input").clear();
+         cy.get("@input").click();
+         cy.get("@input").type("hey friends!");
+         cy.get("@submitButton").click();
+         cy.get("@theComment")
+            .should("not.contain", "hello world!")
+            .should("contain", "hey friends!");
+      });
 
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
+      it("deletes a comment", () => {
+         cy.get("@theComment")
+            .find(".webix_comments_menu")
+            .as("commentMenu")
             .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]')
-            .first()
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('textarea[class="webix_inp_textarea"]')
-            .eq(0)
-            .clear()
-            .click()
-            .type("cypress hahaha");
-
-         pressSendButton();
-
-         cy.get("div")
-            .should("have.class", "webix_comments_message")
-            .should("contain", "cypress hahaha");
-      }); //End 11
-
-      //12. should't have found the text "test" on the first comment
-      it("should't have found the text test on the first comment", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]', { timeout: 30000 })
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('textarea[class="webix_inp_textarea"]')
-            .eq(0)
-            .clear()
-            .click()
-            .type("cypress hahaha");
-
-         pressSendButton();
-
-         cy.get('div[class*="webix_comments_message"]')
-            .first()
-            .should("have.text", "cypress hahaha");
-      }); //End 12
-
-      //13. can find the text "The comment will be removed. Are you sure?"
-      it("can find the text The comment will be removed. Are you sure?", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(1).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class="webix_popup_text"]')
-            .find("span")
-            .should("have.text", "The comment will be removed. Are you sure?");
-      }); //End 13
-
-      //14. can find the button "Cancel" on the popup
-      it("can find the button Cancel on the popup", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(1).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class="webix_popup_button"]').should(
-            "have.text",
-            "Cancel",
-         );
-      }); //End 14
-
-      //15. can find the button which has the text "Ok" on the popup
-      it("can find the button which has the text Ok on the popup", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(1).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class="webix_popup_button confirm"]').should(
-            "have.text",
-            "OK",
-         );
-      }); //End 15
-
-      //16. can find the button which has the text "Cancel" on the popup
-      it("can find the button which has the text Cancel on the popup", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(1).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class="webix_popup_button"]').should(
-            "have.text",
-            "Cancel",
-         );
-      }); //End 16
-
-      //17. the text "cypress hahaha" should exist
-      it("the text cypress hahaha should exist", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(0).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('textarea[class="webix_inp_textarea"]')
-            .eq(0)
-            .clear()
-            .click()
-            .type("cypress hahaha");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(1).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class="webix_popup_button"]')
-            .should("have.text", "Cancel")
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class*="webix_comments_message"]')
-            .first()
-            .should("have.text", "cypress hahaha");
-      }); //End 17
-
-      //18. the text "cypress hahaha" shouldn't exist
-      it("the text cypress hahaha shouldn't exist", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         ).click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("test");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]', { timeout: 30000 })
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('textarea[class="webix_inp_textarea"]')
-            .eq(0)
-            .clear()
-            .click()
-            .type("cypress hahaha");
-
-         pressSendButton();
-
-         // cy.get("div")
-         //    .should("have.class", "webix_list_item webix_comments_current")
-         //    .contains("admin")
-         //    .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('span[class="webix_icon wxi-dots webix_comments_menu"]')
-            .eq(0)
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('a[class="webix_list_item menu"]').eq(1).click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class="webix_popup_button confirm"]')
-            .should("have.text", "OK")
-            .click({ force: true });
-
-         // eslint-disable-next-line cypress/no-unnecessary-waiting
-         cy.wait(500);
-
-         cy.get('div[class*="webix_comments_message"]')
-            .first()
-            .should("not.have.text", "cypress hahaha");
-      }); //End 18
-
-      //19. can find the text "cypress hahaha is coming back" on the comment container
-      it("can find the text cypress hahaha is coming back on the comment container", () => {
-         // cy.RunSQL(folderName, ["add_testkcs.sql"]);
-         cy.get(
-            '[data-cy="tab-Comment-50a1d27a-a4a1-44a5-a264-707df2b07dbb-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
-         )
+         cy.get('[webix_l_id="remove"]')
+            .as("remove")
             .should("be.visible")
             .click();
 
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().click();
-
-         cy.get("textarea").should("have.class", "webix_inp_textarea");
-         cy.get("textarea").first().type("cypress hahaha is coming back");
-
-         pressSendButton();
-
-         cy.get(".webix_list_item")
-            .contains("cypress hahaha is coming back")
-            .should("have.class", "webix_comments_message");
-      }); //End 19
-   }); //End describe
-}; //End Export
-
-/**
- * Finds and presses the send button in a comment widget
- * @funtion pressSendButton
- * @param {int} [ index = 0 ] the index of the comment widget, needed if more than one exist on the page
- */
-function pressSendButton(index = 0) {
-   cy.get(".webix_comments").eq(index).find("button").should("exist").click();
-}
+         //13. can find the text "The comment will be removed. Are you sure?"
+         cy.get("div.webix_popup_text > span").should(
+            "have.text",
+            "The comment will be removed. Are you sure?",
+         );
+         //14. can find the button "Cancel" on the popup
+         cy.get("div.webix_popup_button")
+            .first()
+            .as("cancel")
+            .should("have.text", "Cancel");
+         //15. can find the button which has the text "Ok" on the popup
+         cy.get("div.webix_popup_button")
+            .last()
+            .as("confirm")
+            .should("have.text", "OK");
+         //16. Cancel the delete
+         cy.get("@cancel").click();
+         cy.get("@theComment")
+            .should("be.visible")
+            .and("contain", "hello world!");
+         // 17. Delete the comment
+         cy.get("@commentMenu").click({ force: true });
+         cy.get("@remove").should("be.visible").click();
+         cy.get("@confirm").click();
+         cy.get("@theComment").should("not.exist");
+      });
+   });
+};


### PR DESCRIPTION
- Previously had 19! tests, rewrote it as 3. 
- Reduces repetition to make our test suite faster.
- Removed a bunch of  `cy.wait()`
- Assertions now target the specific widget and comment.