### PR TITLE
Changes that seem to work more consistently

### DIFF
--- a/test_cases/widget_filter_by_connected_record.js
+++ b/test_cases/widget_filter_by_connected_record.js
@@ -30,9 +30,7 @@ export default (folderName) => {
          cy.get('[data-cy^="connectObject options uuid21"]').should(
             "be.visible",
          );
-         cy.get('[data-cy^="connectObject options uuid21"]').click({
-            force: true,
-         });
+         cy.get('[data-cy^="connectObject options uuid21"]').trigger("click");
 
          cy.get('[data-cy^="connectObject connectto3"] .webix_spin').should(
             "not.exist",
@@ -87,7 +85,7 @@ export default (folderName) => {
             .trigger("click");
          cy.get('[data-cy^="connectObject options uuid21"]')
             .should("be.visible")
-            .click({ force: true });
+            .trigger("click");
          cy.get('[data-cy^="connectObject connectto3"] .webix_spin').should(
             "not.exist",
          );

--- a/test_cases/widget_form_save.js
+++ b/test_cases/widget_form_save.js
@@ -23,8 +23,8 @@ export default () => {
             .type("Test Record Rules");
 
          cy.get(
-            '[data-cy="button save 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]'
-         ).click();
+            '[data-cy="button save 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]',
+         ).click({ force: true });
          cy.get(
             '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]'
          ).scrollIntoView();

--- a/test_cases/widget_form_save.js
+++ b/test_cases/widget_form_save.js
@@ -9,13 +9,13 @@ export default () => {
       // });
       beforeEach(() => {
          cy.get(
-            '[data-cy="tab-FormSave-af33a28d-c6a8-4a88-a52a-6d3333c3151f-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]'
+            '[data-cy="tab-FormSave-af33a28d-c6a8-4a88-a52a-6d3333c3151f-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
          ).click();
       });
 
       it("Submit Record Rules Form", () => {
          cy.get(
-            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]'
+            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]',
          )
             .should("be.visible")
             .type("Please work")
@@ -26,24 +26,23 @@ export default () => {
             '[data-cy="button save 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]',
          ).click({ force: true });
          cy.get(
-            '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]'
+            '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]',
          ).scrollIntoView();
          cy.get(".webix_ss_center_scroll").contains("Test Record Rules");
          cy.get(".webix_ss_center_scroll").contains("5");
          cy.get(".webix_ss_center_scroll").contains("Option 2");
          cy.log(
-            "'Mr. Admin' is set in a record rule: selected via data collection current-cursor-select. That method is used in almost every module."
+            "'Mr. Admin' is set in a record rule: selected via data collection current-cursor-select. That method is used in almost every module.",
          );
          // cy.get(".webix_ss_center_scroll").contains("Mr. Admin");
          cy.get(".webix_ss_center_scroll").find(".fa-square-o");
          // this icon seems to be consistently covered by a 'progressbar'
-         cy.get(".trash")
-            .click({force:true});
+         cy.get(".trash").click({ force: true });
          cy.get(".webix_popup_button.confirm").should("be.visible").click();
       });
       it("Submit Default Values Form", () => {
          cy.get(
-            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 0181c44e-08ec-4953-beee-d6b36d02b1eb"]'
+            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 0181c44e-08ec-4953-beee-d6b36d02b1eb"]',
          )
             .should("exist")
             .type("Please work")
@@ -51,50 +50,50 @@ export default () => {
             .type("Test Default Values");
 
          cy.get(
-            '[data-cy="button save 0181c44e-08ec-4953-beee-d6b36d02b1eb"]'
+            '[data-cy="button save 0181c44e-08ec-4953-beee-d6b36d02b1eb"]',
          ).click();
          cy.get(".webix_ss_center_scroll").contains("Test Default Values");
          cy.get(".webix_ss_center_scroll").contains("1");
          cy.get(".webix_ss_center_scroll").contains("Option 3");
          cy.get(".webix_ss_center_scroll").find(".fa-check-square-o");
-         cy.get(".trash")
-            .click({force:true});
+         cy.get(".trash").click({ force: true });
          cy.get(".webix_popup_button.confirm").should("be.visible").click();
       });
       it("Submit Empty Number Field", () => {
          cy.get('[data-cy="button save 0181c44e-08ec-4953-beee-d6b36d02b1eb"]')
             .should("exist")
             .click();
-         cy.get(".edit")
-            .should("be.visible", { timeout: 50000, retryInterval: 500 })
-         cy.get(".edit")
-            .click();
+         cy.get(".edit").should("be.visible", {
+            timeout: 50000,
+            retryInterval: 500,
+         });
+         cy.get(".edit").click();
          cy.get(
-            '[data-cy="detail text Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 ee223876-f1a2-4e69-837e-557ab2a3a3ba"]'
+            '[data-cy="detail text Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 ee223876-f1a2-4e69-837e-557ab2a3a3ba"]',
          )
             .should("be.visible")
             .find(".ab-detail-component-holder")
             .should("be.empty");
          cy.get(
-            '[data-cy="number Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 c8d8a6fb-783a-409c-949d-ac94c959a49b"]'
+            '[data-cy="number Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 c8d8a6fb-783a-409c-949d-ac94c959a49b"]',
          )
             .type("1111")
             .clear()
             .type("20");
          cy.get(
-            '[data-cy="button save c8d8a6fb-783a-409c-949d-ac94c959a49b"]'
+            '[data-cy="button save c8d8a6fb-783a-409c-949d-ac94c959a49b"]',
          ).click();
          cy.get(
-            '[data-cy="detail text Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 ee223876-f1a2-4e69-837e-557ab2a3a3ba"]'
+            '[data-cy="detail text Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 ee223876-f1a2-4e69-837e-557ab2a3a3ba"]',
          ).contains("20");
          cy.get(
-            '[data-cy="number Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 c8d8a6fb-783a-409c-949d-ac94c959a49b"]'
+            '[data-cy="number Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 c8d8a6fb-783a-409c-949d-ac94c959a49b"]',
          ).clear();
          cy.get(
-            '[data-cy="button save c8d8a6fb-783a-409c-949d-ac94c959a49b"]'
+            '[data-cy="button save c8d8a6fb-783a-409c-949d-ac94c959a49b"]',
          ).click();
          cy.get(
-            '[data-cy="detail text Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 ee223876-f1a2-4e69-837e-557ab2a3a3ba"]'
+            '[data-cy="detail text Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 ee223876-f1a2-4e69-837e-557ab2a3a3ba"]',
          )
             .find(".ab-detail-component-holder")
             .should("be.empty");
@@ -102,18 +101,18 @@ export default () => {
 
       it.skip("conditional record rules - 0", () => {
          cy.get(
-            '[data-cy="tab-Menu-773dca98-87e0-4dc2-b528-89ec7c98c448-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]'
+            '[data-cy="tab-Menu-773dca98-87e0-4dc2-b528-89ec7c98c448-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
          ).click();
 
          // init some data
          cy.get(
-            '[data-cy="menu-item initiate sub records 743969bc-cb8f-471e-abcd-1f4511b83815 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]'
+            '[data-cy="menu-item initiate sub records 743969bc-cb8f-471e-abcd-1f4511b83815 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]',
          )
             .should("be.visible")
             .click();
 
          cy.get(
-            '[data-cy="number amount 79902266-40e5-463a-9869-cee01ef955a0 a573443e-6b82-4db9-a827-0a772a53af74"]'
+            '[data-cy="number amount 79902266-40e5-463a-9869-cee01ef955a0 a573443e-6b82-4db9-a827-0a772a53af74"]',
          )
             .should("be.visible")
             .type("1")
@@ -123,13 +122,13 @@ export default () => {
          // will redirect us to a new view and it may be too late to click the
          // first button at that time.
          cy.get(
-            '[data-cy="button save a573443e-6b82-4db9-a827-0a772a53af74"]'
+            '[data-cy="button save a573443e-6b82-4db9-a827-0a772a53af74"]',
          ).click();
 
          cy.get(".webix_spin").should("not.exist");
 
          cy.get(
-            '[data-cy="number amount 7c8732a7-9f55-4844-be4e-51978f94d712 63c31c80-81ff-4114-8aec-cd4d43c2533a"]'
+            '[data-cy="number amount 7c8732a7-9f55-4844-be4e-51978f94d712 63c31c80-81ff-4114-8aec-cd4d43c2533a"]',
          )
             .type("-1")
             .clear()
@@ -143,7 +142,7 @@ export default () => {
 
          // pre-setup the data in the popup
          cy.get(
-            '[data-cy^="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79"]'
+            '[data-cy^="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79"]',
          )
             .contains("Condition rule")
             .should("be.visible")
@@ -152,7 +151,7 @@ export default () => {
          cy.get('[data-cy^="connectObject Orders"]').should("be.visible");
 
          cy.get('[data-cy^="connectObject Orders"] .webix_spin').should(
-            "not.exist"
+            "not.exist",
          );
 
          cy.get('[data-cy^="connectObject Orders"]')
@@ -165,14 +164,14 @@ export default () => {
             .click({ force: true });
 
          cy.get(
-            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]'
+            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]',
          )
             .should("be.visible")
             .click();
 
          cy.get('[data-cy^="connectObject Processes"]').should("be.visible");
          cy.get('[data-cy^="connectObject Processes"].webix_spin').should(
-            "not.exist"
+            "not.exist",
          );
 
          cy.get('[data-cy^="connectObject Processes"]')
@@ -185,7 +184,7 @@ export default () => {
             .click({ force: true });
 
          cy.get(
-            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]'
+            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]',
          )
             .should("be.visible")
             .click();
@@ -200,7 +199,7 @@ export default () => {
 
          // open the popup
          cy.get(
-            '[data-cy^="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79"]'
+            '[data-cy^="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79"]',
          )
             .contains("Condition rule")
             .should("be.visible")
@@ -214,14 +213,14 @@ export default () => {
          cy.get(".webix_spin").should("not.exist");
 
          cy.get('[view_id="de0a9a23-8204-4317-9026-97ede2670f79"').should(
-            "not.be.visible"
+            "not.be.visible",
          );
 
          // hack to get the test to pass in headless browser
          cy.wait(100);
 
          cy.get(
-            '[data-cy="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]'
+            '[data-cy="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]',
          )
             .contains("Condition rule")
             .should("be.visible")
@@ -230,19 +229,19 @@ export default () => {
          cy.get(".webix_spin").should("not.exist");
 
          cy.get('[view_id="de0a9a23-8204-4317-9026-97ede2670f79"]').should(
-            "be.visible"
+            "be.visible",
          );
 
          // check whether balance check already exists
          cy.get(
-            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]'
+            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]',
          )
             .contains("0")
             .should("not.contain", "185")
             .should("be.visible");
          //
          cy.get(
-            '[data-cy="number Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 c7cff6a1-dfed-467c-a3dc-481124f9926d"]'
+            '[data-cy="number Number allow empty b75b3530-b5de-4ca8-b136-0503c4c9a8c2 c7cff6a1-dfed-467c-a3dc-481124f9926d"]',
          )
             .should("be.visible")
             .click()
@@ -265,15 +264,15 @@ export default () => {
          if it doesn't work, submit conditional record rules are totally broken`);
          // are we there?
          cy.get(
-            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 0181c44e-08ec-4953-beee-d6b36d02b1eb"]'
+            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 0181c44e-08ec-4953-beee-d6b36d02b1eb"]',
          )
             // .scrollIntoView()
             .should("be.visible");
          cy.get(
-            '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]'
+            '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]',
          ).scrollIntoView();
          cy.log(
-            "If the record exists, but the data is wrong, it means the forms works -- and the record rules don't"
+            "If the record exists, but the data is wrong, it means the forms works -- and the record rules don't",
          );
          cy.get(".webix_ss_center_scroll").contains("Number was zero");
          cy.get(".webix_ss_center_scroll").contains("0");
@@ -286,17 +285,17 @@ export default () => {
       });
       it.skip("conditional record rules - greater than 1", () => {
          cy.get(
-            '[data-cy="tab-Menu-773dca98-87e0-4dc2-b528-89ec7c98c448-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]'
+            '[data-cy="tab-Menu-773dca98-87e0-4dc2-b528-89ec7c98c448-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
          ).click();
          // init some data
          cy.get(
-            '[data-cy="menu-item initiate sub records 743969bc-cb8f-471e-abcd-1f4511b83815 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]'
+            '[data-cy="menu-item initiate sub records 743969bc-cb8f-471e-abcd-1f4511b83815 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]',
          )
             .should("be.visible")
             .click();
 
          cy.get(
-            '[data-cy="number amount 79902266-40e5-463a-9869-cee01ef955a0 a573443e-6b82-4db9-a827-0a772a53af74"]'
+            '[data-cy="number amount 79902266-40e5-463a-9869-cee01ef955a0 a573443e-6b82-4db9-a827-0a772a53af74"]',
          )
             .should("be.visible")
             .type("1")
@@ -304,28 +303,28 @@ export default () => {
             .type("85");
          // button save a573443e-6b82-4db9-a827-0a772a53af74
          cy.get(
-            '[data-cy="number amount 7c8732a7-9f55-4844-be4e-51978f94d712 63c31c80-81ff-4114-8aec-cd4d43c2533a"]'
+            '[data-cy="number amount 7c8732a7-9f55-4844-be4e-51978f94d712 63c31c80-81ff-4114-8aec-cd4d43c2533a"]',
          )
             .type("-1")
             .clear()
             .type("85");
          // click save buttons
          cy.get(
-            '[data-cy="button save a573443e-6b82-4db9-a827-0a772a53af74"]'
+            '[data-cy="button save a573443e-6b82-4db9-a827-0a772a53af74"]',
          ).click();
 
          cy.get(
-            '[data-cy="button save 63c31c80-81ff-4114-8aec-cd4d43c2533a"]'
+            '[data-cy="button save 63c31c80-81ff-4114-8aec-cd4d43c2533a"]',
          ).click();
 
          cy.get(
-            '[data-cy="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]'
+            '[data-cy="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79 88bb72eb-5908-46e5-9c87-1e4c6637e6c7"]',
          )
             .should("be.visible")
             .click();
 
          cy.get(
-            '[data-cy="connectObject Orders f03063b2-cfab-4778-b356-466810217f21 92d50041-cda0-4f3b-a215-c078a50d828a"]'
+            '[data-cy="connectObject Orders f03063b2-cfab-4778-b356-466810217f21 92d50041-cda0-4f3b-a215-c078a50d828a"]',
          )
             .should("be.visible")
             .click();
@@ -334,20 +333,20 @@ export default () => {
             .first()
             .click();
          cy.get(
-            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]'
+            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]',
          )
             .filter(":visible")
             .click();
 
          cy.get(
-            '[data-cy^="connectObject Processes d60649b7-d722-47e2-9c9d-40ae1387f5ba 92d50041-cda0-4f3b-a215-c078a50d828a"]'
+            '[data-cy^="connectObject Processes d60649b7-d722-47e2-9c9d-40ae1387f5ba 92d50041-cda0-4f3b-a215-c078a50d828a"]',
          ).click();
          cy.get('[data-cy^="connectObject options"]')
             .should("be.visible")
             .first()
             .click();
          cy.get(
-            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]'
+            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]',
          )
             .filter(":visible")
             .click();
@@ -360,13 +359,13 @@ export default () => {
 
          // open the popup
          cy.get(
-            '[data-cy^="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79"]'
+            '[data-cy^="menu-item conditional record rule de0a9a23-8204-4317-9026-97ede2670f79"]',
          )
             .contains("Condition rule")
             .should("exist")
             .click();
          cy.get(
-            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]'
+            '[data-cy^="detail text balance check example b42e1e16-15ff-4c85-abb5-4b2e9d80ff32"]',
          )
             .contains("170.00")
             .should("exist");
@@ -392,15 +391,15 @@ export default () => {
          if it doesn't work, submit conditional record rules are totally broken`);
          // are we there?
          cy.get(
-            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 0181c44e-08ec-4953-beee-d6b36d02b1eb"]'
+            '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 0181c44e-08ec-4953-beee-d6b36d02b1eb"]',
          )
             // .scrollIntoView()
             .should("be.visible");
          cy.get(
-            '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]'
+            '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]',
          ).scrollIntoView();
          cy.log(
-            "If the record exists, but the data is wrong, it means the forms works -- and the record rules don't"
+            "If the record exists, but the data is wrong, it means the forms works -- and the record rules don't",
          );
          cy.get(".webix_ss_center_scroll").contains("Number was positive");
          cy.get(".webix_ss_center_scroll").contains("1337");
@@ -416,7 +415,7 @@ export default () => {
             .should("exist")
             .contains("1337");
          cy.get(
-            '[data-cy^="detail text Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b"]'
+            '[data-cy^="detail text Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b"]',
          )
             .filter(":visible")
             .should("exist")


### PR DESCRIPTION
These references to web popup panels for connection drop-downs seemed to work better with `.trigger("click")` than with `.click()`



## Release Notes
<!-- #release_notes -->
- [wip] these changes seemed to work more consistently on my machine
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
