### PR TITLE
Additional tweaks to make sure all test pass consistently on my local machine (and hopefully in GitHub)

### DIFF
--- a/appbuilder_app.json
+++ b/appbuilder_app.json
@@ -1,7 +1,7 @@
 {
   "abVersion": "0.0.0",
-  "filename": "app_kitchen-sink_20240426",
-  "date": "20240426",
+  "filename": "app_kitchen-sink_20240520",
+  "date": "20240520",
   "definitions": [
     {
       "id": "0ac51d6c-7c95-461c-aa8b-7da00afc4f48",
@@ -6968,6 +6968,115 @@
       },
       "createdAt": "2022-04-07T09:33:23.000Z",
       "updatedAt": "2022-04-07T09:33:23.000Z"
+    },
+    {
+      "id": "14038fde-cf9d-4627-be3b-31537fb1b181",
+      "name": "test-kcs-Text",
+      "type": "object",
+      "json": {
+        "id": "14038fde-cf9d-4627-be3b-31537fb1b181",
+        "type": "object",
+        "name": "test-kcs-Text",
+        "labelFormat": "",
+        "labelSettings": {
+          "isNoLabelDisplay": 0
+        },
+        "isImported": 0,
+        "isExternal": 0,
+        "tableName": "AB_kitchensink_testkcsText",
+        "primaryColumnName": "uuid",
+        "transColumnName": "",
+        "urlPath": "",
+        "objectWorkspace": {
+          "sortFields": [],
+          "filterConditions": [],
+          "frozenColumnID": "",
+          "hiddenFields": []
+        },
+        "isSystemObject": 0,
+        "translations": [
+          {
+            "language_code": "en",
+            "label": "test-kcs-Text"
+          }
+        ],
+        "fieldIDs": [
+          "870ade80-e7b2-4ded-8b11-e60c5911d707",
+          "80ce1807-3962-46be-988b-316f98e90d20"
+        ],
+        "importedFieldIDs": [],
+        "indexIDs": [],
+        "createdInAppID": "0ac51d6c-7c95-461c-aa8b-7da00afc4f48"
+      },
+      "createdAt": "2024-03-05T23:48:40.000Z",
+      "updatedAt": "2024-03-06T00:22:49.000Z"
+    },
+    {
+      "id": "870ade80-e7b2-4ded-8b11-e60c5911d707",
+      "name": "test-kcs-Text->longtext",
+      "type": "field",
+      "json": {
+        "id": "870ade80-e7b2-4ded-8b11-e60c5911d707",
+        "type": "field",
+        "key": "LongText",
+        "icon": "align-right",
+        "isImported": 0,
+        "columnName": "longtext",
+        "settings": {
+          "showIcon": 1,
+          "required": 0,
+          "unique": 0,
+          "validationRules": "[]",
+          "default": "",
+          "supportMultilingual": 0,
+          "width": 120
+        },
+        "translations": [
+          {
+            "language_code": "en",
+            "label": "longtext"
+          }
+        ]
+      },
+      "createdAt": "2024-03-05T23:48:54.000Z",
+      "updatedAt": "2024-03-05T23:48:54.000Z"
+    },
+    {
+      "id": "80ce1807-3962-46be-988b-316f98e90d20",
+      "name": "test-kcs-Text->sort",
+      "type": "field",
+      "json": {
+        "id": "80ce1807-3962-46be-988b-316f98e90d20",
+        "type": "field",
+        "key": "number",
+        "icon": "hashtag",
+        "isImported": 0,
+        "columnName": "sort",
+        "settings": {
+          "showIcon": 1,
+          "required": 0,
+          "unique": 0,
+          "validationRules": "[]",
+          "default": "",
+          "typeFormat": "none",
+          "typeDecimals": "none",
+          "typeDecimalPlaces": 0,
+          "typeRounding": "none",
+          "typeThousands": "none",
+          "validation": 0,
+          "validateMinimum": "",
+          "validateMaximum": "",
+          "width": 100
+        },
+        "translations": [
+          {
+            "language_code": "en",
+            "label": "sort"
+          }
+        ]
+      },
+      "createdAt": "2024-03-06T00:22:48.000Z",
+      "updatedAt": "2024-03-06T00:22:48.000Z"
     },
     {
       "id": "952b8424-bd56-4d93-a937-7889fc5a46d6",
@@ -20232,27 +20341,32 @@
         "type": "view",
         "key": "text",
         "icon": "font",
+        "name": "Text.text",
         "settings": {
-          "columnSpan": "1",
-          "rowSpan": "1",
+          "columnSpan": 1,
+          "rowSpan": 1,
           "height": 0,
-          "dataviewID": "2900d309-e9c3-434f-b937-202d8a972a11"
+          "dataviewID": "63278f55-c2c4-4725-9272-6125e0eb20f6",
+          "name": "Text.text"
         },
+        "accessLevels": {},
         "translations": [
           {
             "language_code": "en",
-            "text": "<p>{long-text}</p>",
+            "text": "<p>{longtext}</p>",
             "label": "Text.text"
           }
         ],
+        "viewIDs": [],
         "position": {
           "dx": 1,
           "dy": 1
         },
-        "isRoot": "false"
+        "isRoot": false,
+        "views": []
       },
       "createdAt": "2021-09-14T06:50:01.000Z",
-      "updatedAt": "2021-09-14T06:50:13.000Z"
+      "updatedAt": "2024-03-05T23:52:14.000Z"
     },
     {
       "id": "b5657df0-bc8a-4fc8-bd00-8c0928932ffc",
@@ -23005,38 +23119,31 @@
       "name": "Form.form.textbox",
       "type": "view",
       "json": {
-        "id": "4ce791a0-f7af-4b64-91f3-37bbe4bb6e60",
         "type": "view",
         "key": "textbox",
         "icon": "i-cursor",
-        "name": "Form.form.textbox",
         "settings": {
-          "type": "rich",
+          "type": "multiple",
           "objectId": "01e0c6d4-ab5e-41ca-8715-77f0424e623f",
           "fieldId": "f36f0f53-6044-43d6-bdc9-4f2b675c37a5",
-          "height": 0,
-          "name": "Form.form.textbox",
-          "fieldLabel": "long-text",
-          "required": 0,
-          "disable": 0
+          "height": 0
         },
-        "accessLevels": {},
         "translations": [
           {
             "language_code": "en",
             "label": "Form.form.textbox"
           }
         ],
-        "viewIDs": [],
         "position": {
           "dx": 1,
           "dy": 1,
           "y": 3
         },
-        "isRoot": false
+        "isRoot": "false",
+        "id": "4ce791a0-f7af-4b64-91f3-37bbe4bb6e60"
       },
       "createdAt": "2021-09-14T07:09:02.000Z",
-      "updatedAt": "2024-04-26T04:21:18.000Z"
+      "updatedAt": "2021-09-14T07:09:02.000Z"
     },
     {
       "id": "844180aa-9c64-408e-a529-10d199c36254",
@@ -23080,28 +23187,32 @@
         "icon": "i-cursor",
         "name": "Form.form.textbox",
         "settings": {
-          "type": "single",
+          "type": "rich",
           "objectId": "01e0c6d4-ab5e-41ca-8715-77f0424e623f",
           "fieldId": "78d60c46-5523-474d-8e0c-d8d6db814be8",
-          "required": "0",
-          "disable": "0",
-          "height": 0
+          "required": 0,
+          "disable": 0,
+          "height": 0,
+          "name": "Form.form.textbox",
+          "fieldLabel": "single-line-text"
         },
+        "accessLevels": {},
         "translations": [
           {
             "language_code": "en",
             "label": "Form.form.textbox"
           }
         ],
+        "viewIDs": [],
         "position": {
           "dx": 1,
           "dy": 1,
           "y": 1
         },
-        "isRoot": "false"
+        "isRoot": false
       },
       "createdAt": "2021-09-14T07:09:02.000Z",
-      "updatedAt": "2021-09-14T07:45:11.000Z"
+      "updatedAt": "2024-05-20T08:43:32.000Z"
     },
     {
       "id": "b458c9a3-2b12-46f5-b586-3b5a99a70ccc",
@@ -23495,25 +23606,28 @@
         "icon": "list-alt",
         "name": "Form Save.form",
         "settings": {
-          "columns": "2",
-          "removable": "true",
-          "movable": "true",
+          "columns": 2,
+          "removable": true,
+          "movable": true,
           "labelPosition": "left",
-          "showLabel": "1",
-          "clearOnLoad": "0",
-          "clearOnSave": "1",
-          "labelWidth": "60",
+          "showLabel": 1,
+          "clearOnLoad": 0,
+          "clearOnSave": 1,
+          "labelWidth": 60,
           "height": 200,
           "dataviewID": "8b69b2a3-ba4a-4c31-9706-5190db5c5a86",
           "gravity": [
-            "1",
-            "2"
-          ]
+            1,
+            2
+          ],
+          "recordRules": [],
+          "submitRules": []
         },
+        "accessLevels": {},
         "translations": [
           {
             "language_code": "en",
-            "label": "Form Save.form"
+            "label": "Form Save2.form"
           }
         ],
         "viewIDs": [
@@ -23526,10 +23640,10 @@
           "x": 0,
           "y": 3
         },
-        "isRoot": "false"
+        "isRoot": false
       },
       "createdAt": "2022-03-15T02:26:32.000Z",
-      "updatedAt": "2022-06-23T07:19:57.000Z"
+      "updatedAt": "2024-05-08T23:37:12.000Z"
     },
     {
       "id": "8f2b6202-7c95-4b78-83b0-bc406e283868",
@@ -23545,24 +23659,30 @@
           "type": "single",
           "objectId": "efdf6230-2013-459c-9c0e-a8c25521f31a",
           "fieldId": "2e7a1c02-141a-4cdd-b93e-62c6c4e4765b",
-          "height": 0
+          "height": 0,
+          "name": "Form Save2.form.textbox",
+          "fieldLabel": "Title",
+          "required": 0,
+          "disable": 0
         },
+        "accessLevels": {},
         "translations": [
           {
             "language_code": "en",
-            "label": "Form Save.form.textbox"
+            "label": "Form Save2.form.textbox"
           }
         ],
+        "viewIDs": [],
         "position": {
           "dx": 1,
           "dy": 1,
           "y": 0,
           "x": 0
         },
-        "isRoot": "false"
+        "isRoot": false
       },
       "createdAt": "2022-03-15T02:26:41.000Z",
-      "updatedAt": "2022-06-14T08:26:28.000Z"
+      "updatedAt": "2024-05-08T23:36:37.000Z"
     },
     {
       "id": "1b06d7c9-83e7-47f2-9a28-1100440d256c",
@@ -23575,33 +23695,39 @@
         "icon": "square",
         "name": "Form Save.form.button",
         "settings": {
-          "includeSave": "1",
-          "includeCancel": "0",
-          "includeReset": "1",
-          "isDefault": "true",
+          "includeSave": true,
+          "includeCancel": false,
+          "includeReset": 1,
+          "isDefault": true,
           "saveLabel": "",
           "cancelLabel": "",
           "resetLabel": "",
           "afterCancel": "",
           "alignment": "left",
-          "height": 0
+          "height": 0,
+          "translations": [],
+          "includeDelete": false,
+          "name": "Form Save2.form.button",
+          "deleteLabel": ""
         },
+        "accessLevels": {},
         "translations": [
           {
             "language_code": "en",
-            "label": "Form Save.form.button"
+            "label": "Form Save2.form.button"
           }
         ],
+        "viewIDs": [],
         "position": {
           "dx": 1,
           "dy": 1,
           "y": 0,
           "x": 1
         },
-        "isRoot": "false"
+        "isRoot": false
       },
       "createdAt": "2022-03-15T02:26:41.000Z",
-      "updatedAt": "2022-06-14T08:26:28.000Z"
+      "updatedAt": "2024-05-08T23:36:50.000Z"
     },
     {
       "id": "42938e52-9da9-4ece-b492-deb253244d3e",
@@ -24365,8 +24491,8 @@
           "columnSpan": 1,
           "rowSpan": 1,
           "name": "No Link.list",
-          "dataviewID": "2900d309-e9c3-434f-b937-202d8a972a11",
-          "field": "78d60c46-5523-474d-8e0c-d8d6db814be8"
+          "dataviewID": "3ff56904-668e-40db-80f4-b92e97c40781",
+          "field": "310fc3dd-62be-40cb-a018-0afeabba211f"
         },
         "accessLevels": {},
         "translations": [
@@ -24383,7 +24509,7 @@
         "isRoot": false
       },
       "createdAt": "2023-10-20T08:29:57.000Z",
-      "updatedAt": "2023-10-20T08:30:51.000Z"
+      "updatedAt": "2024-03-06T19:09:11.000Z"
     },
     {
       "id": "baae6c32-ca96-4e21-acd2-7a54f57de3d8",
@@ -27476,8 +27602,8 @@
   "files": {
     "072676f0-cb19-4d73-b68b-cc8c80ebe2ce": {
       "meta": {
-        "created_at": "2024-04-26 04:16:08",
-        "updated_at": "2024-04-26 04:16:08",
+        "created_at": "2024-05-20 08:30:20",
+        "updated_at": "2024-05-20 08:30:20",
         "field": null,
         "object": null,
         "file": "072676f0-cb19-4d73-b68b-cc8c80ebe2ce.docx",
@@ -27491,8 +27617,8 @@
     "789747da-ba6e-42dd-80e8-485e3fbe5b97": null,
     "fb91686f-43af-47b0-981c-3b3d179270b0": {
       "meta": {
-        "created_at": "2024-04-26 04:16:07",
-        "updated_at": "2024-04-26 04:16:07",
+        "created_at": "2024-05-20 08:30:20",
+        "updated_at": "2024-05-20 08:30:20",
         "field": "5d41635a-4e20-4159-9a9a-7aafff38feba",
         "object": "01e0c6d4-ab5e-41ca-8715-77f0424e623f",
         "file": "fb91686f-43af-47b0-981c-3b3d179270b0.png",
@@ -27515,8 +27641,8 @@
   "scopes": [
     {
       "uuid": "6fc24a82-01f6-4fb4-b45b-e734ecb8e87e",
-      "created_at": "2024-04-26T04:16:08.000Z",
-      "updated_at": "2024-04-26T04:16:08.000Z",
+      "created_at": "2024-05-20T08:30:20.000Z",
+      "updated_at": "2024-05-20T08:30:20.000Z",
       "properties": null,
       "translations": [
         {
@@ -27554,8 +27680,8 @@
     },
     {
       "uuid": "7d54e52e-65e6-4da7-8faa-26aed0c1160e",
-      "created_at": "2024-04-26T04:16:09.000Z",
-      "updated_at": "2024-04-26T04:16:09.000Z",
+      "created_at": "2024-05-20T08:30:20.000Z",
+      "updated_at": "2024-05-20T08:30:20.000Z",
       "properties": null,
       "translations": [
         {
@@ -27584,8 +27710,8 @@
     },
     {
       "uuid": "506a6815-0073-436e-9e2a-b5bc6b655b8a",
-      "created_at": "2024-04-26T04:16:09.000Z",
-      "updated_at": "2024-04-26T04:16:09.000Z",
+      "created_at": "2024-05-20T08:30:20.000Z",
+      "updated_at": "2024-05-20T08:30:20.000Z",
       "properties": null,
       "translations": [
         {
@@ -27615,8 +27741,8 @@
   "roles": [
     {
       "uuid": "4cb11fa7-3d79-412c-9a03-0ce8d7210cde",
-      "created_at": "2024-04-26T04:16:09.000Z",
-      "updated_at": "2024-04-26T04:16:09.000Z",
+      "created_at": "2024-05-20T08:30:20.000Z",
+      "updated_at": "2024-05-20T08:30:20.000Z",
       "properties": null,
       "translations": [
         {
@@ -27640,8 +27766,8 @@
     },
     {
       "uuid": "c9093730-0176-4f72-b410-bfb6856ff713",
-      "created_at": "2024-04-26T04:16:09.000Z",
-      "updated_at": "2024-04-26T04:16:09.000Z",
+      "created_at": "2024-05-20T08:30:20.000Z",
+      "updated_at": "2024-05-20T08:30:20.000Z",
       "properties": null,
       "translations": [
         {
@@ -27665,8 +27791,8 @@
     },
     {
       "uuid": "eb4f75ea-c995-4fc6-8bab-0ab2d6552508",
-      "created_at": "2024-04-26T04:16:09.000Z",
-      "updated_at": "2024-04-26T04:16:09.000Z",
+      "created_at": "2024-05-20T08:30:20.000Z",
+      "updated_at": "2024-05-20T08:30:20.000Z",
       "properties": null,
       "translations": [
         {

--- a/test_cases/dataCollection.js
+++ b/test_cases/dataCollection.js
@@ -132,26 +132,12 @@ export default () => {
          ).should("be.visible");
 
          // Click to show the scroll bar
-         cy.get(
-            '[data-cy="ABViewGrid_d08be402-470e-4b9d-b5f4-72e27426522c_datatable"]',
-         )
-            .find(".webix_ss_body .webix_ss_right")
-            .click();
 
-         // Close the popup
-         cy.get(
-            '[data-cy="Popup Close Button Edit TestKCS 5403c1cf-57f9-463d-b306-799d3641be11"]',
-         ).click();
-
-         // Drag the scroll bar to bottom
-         cy.get(
-            '[data-cy="ABViewGrid_d08be402-470e-4b9d-b5f4-72e27426522c_datatable"]',
-         )
-            .find(".webix_c_scroll_y")
-            .should("be.visible")
-            .trigger("mousedown")
-            .trigger("mousemove", { which: 1, pageY: 2000 })
-            .trigger("mouseup");
+         cy.GridScroll(
+            "ABViewGrid_d08be402-470e-4b9d-b5f4-72e27426522c_datatable",
+            0,
+            2000,
+         );
 
          // Select the edit item
          cy.get(

--- a/test_cases/dataCollection.js
+++ b/test_cases/dataCollection.js
@@ -20,12 +20,12 @@ export default () => {
             .as("list")
             .should("be.visible")
             .find(".webix_dataview_item")
-            .should("have.length", 18);
+            .should("have.length", 3);
          // add a new record, should see it
          cy.request("POST", `/app_builder/model/${testkcsObjectID}`, {
             singlelinetext: "new",
          });
-         cy.get("@list").find(".webix_dataview_item").should("have.length", 18);
+         cy.get("@list").find(".webix_dataview_item").should("have.length", 3);
       });
 
       it("Linked DC loads data according to parent cursor", () => {

--- a/test_cases/process_test-kcs-onCreate-process.js
+++ b/test_cases/process_test-kcs-onCreate-process.js
@@ -9,13 +9,11 @@ export default (folderName, Common) => {
       it('Process inserts a record after inserting a label value on the tab "process > onCreate"', () => {
          cy.get(
             '[data-cy="string label 06a93149-590d-4e4f-9463-5ff43a689fd1 2172ba78-b327-42a1-8918-d97852234aee"]',
-         ).type("test label", { delay: 0 });
-
-         cy.wait(1000);
-
-         cy.get(
-            '[data-cy="string label 06a93149-590d-4e4f-9463-5ff43a689fd1 2172ba78-b327-42a1-8918-d97852234aee"]',
-         ).type("test label", { delay: 0 });
+         )
+            .as("inputField")
+            .type("test label")
+            .clear();
+         cy.get("@inputField").type("test label", { delay: 0 });
 
          cy.get(
             '[data-cy="button save 2172ba78-b327-42a1-8918-d97852234aee"]',

--- a/test_cases/process_test-kcs-onCreate-process.js
+++ b/test_cases/process_test-kcs-onCreate-process.js
@@ -9,7 +9,13 @@ export default (folderName, Common) => {
       it('Process inserts a record after inserting a label value on the tab "process > onCreate"', () => {
          cy.get(
             '[data-cy="string label 06a93149-590d-4e4f-9463-5ff43a689fd1 2172ba78-b327-42a1-8918-d97852234aee"]',
-         ).type("test label");
+         ).type("test label", { delay: 0 });
+
+         cy.wait(1000);
+
+         cy.get(
+            '[data-cy="string label 06a93149-590d-4e4f-9463-5ff43a689fd1 2172ba78-b327-42a1-8918-d97852234aee"]',
+         ).type("test label", { delay: 0 });
 
          cy.get(
             '[data-cy="button save 2172ba78-b327-42a1-8918-d97852234aee"]',
@@ -32,6 +38,12 @@ export default (folderName, Common) => {
          // cy.log(
          //    "There are two labels: the one we are looking for contains the word 'None'",
          // );
+
+         cy.get(
+            '[data-cy="ABViewGrid_4c2af349-da19-407e-9db0-ab34d1a35837_datatable"]',
+         )
+            .find('[column="1"] > .webix_cell')
+            .should("not.be.empty");
 
          cy.get(
             '[data-cy="ABViewGrid_4c2af349-da19-407e-9db0-ab34d1a35837_datatable"]',

--- a/test_cases/widget_filter_by_connected_record.js
+++ b/test_cases/widget_filter_by_connected_record.js
@@ -53,6 +53,9 @@ export default (folderName) => {
          cy.get('[data-cy^="connectObject options uuid22"]')
             .should("be.visible")
             .click({ force: true });
+
+         cy.get(".webix_progress_icon").should("not.exist");
+
          cy.get('[data-cy^="connectObject connectto3"]').should("be.visible");
          cy.get('[data-cy^="connectObject connectto3"]')
             .find("input")

--- a/test_cases/widget_form_save.js
+++ b/test_cases/widget_form_save.js
@@ -18,9 +18,7 @@ export default () => {
             '[data-cy="string Title 2e7a1c02-141a-4cdd-b93e-62c6c4e4765b 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]',
          )
             .should("be.visible")
-            .type("Please work")
-            .clear()
-            .type("Test Record Rules");
+            .type("Test Record Rules", { delay: 0 });
 
          cy.get(
             '[data-cy="button save 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]',

--- a/test_cases/widget_form_save.js
+++ b/test_cases/widget_form_save.js
@@ -20,9 +20,9 @@ export default () => {
             .should("be.visible")
             .type("Test Record Rules", { delay: 0 });
 
-         cy.get(
-            '[data-cy="button save 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]',
-         ).click({ force: true });
+         cy.get('[data-cy="button save 7e074587-ddc5-4d34-9f37-a0ab88a4258b"]')
+            .should("be.enabled")
+            .click({ force: true });
          cy.get(
             '[data-cy^="ABViewGrid_42938e52-9da9-4ece-b492-deb253244d3e_datatable"]',
          ).scrollIntoView();

--- a/test_cases/widget_grid.js
+++ b/test_cases/widget_grid.js
@@ -3,17 +3,17 @@ export default () => {
    describe("Grid", () => {
       beforeEach(() => {
          cy.get(
-            '[data-cy="tab-Grid-e7c04584-4fbd-4ca9-b64b-0f5bcb477c1e-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]'
+            '[data-cy="tab-Grid-e7c04584-4fbd-4ca9-b64b-0f5bcb477c1e-b52e6e96-5033-4c7f-a104-29bd5ddcac4a"]',
          )
             .should("exist")
             .click();
       });
       it("Exists", () => {
          cy.get(
-            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_toolbar"]'
+            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_toolbar"]',
          ).should("exist");
          cy.get(
-            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_datatable"]'
+            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_datatable"]',
          ).should("exist");
       });
       it("Can edit connected records", () => {
@@ -39,7 +39,7 @@ export default () => {
             .then(($column) => {
                const mmIndex = $column.attr("column");
                cy.get(
-                  `.webix_column[column="${mmIndex}"] > [role="gridcell"][aria-rowindex="1"]`
+                  `.webix_column[column="${mmIndex}"] > [role="gridcell"][aria-rowindex="1"]`,
                )
                   .should("exist")
                   .click({ force: true });
@@ -54,7 +54,7 @@ export default () => {
                   .click();
                cy.get(".webix_button").contains("Select").click();
                cy.get(
-                  `.webix_column[column="${mmIndex}"] > [role="gridcell"][aria-rowindex="1"]`
+                  `.webix_column[column="${mmIndex}"] > [role="gridcell"][aria-rowindex="1"]`,
                )
                   .should("contain", "test-KCS-ID:0000000001")
                   .and("contain", "test-KCS-ID:0000000002");
@@ -62,7 +62,7 @@ export default () => {
          // One Side
          cy.GridScroll(GRID, connect_om.pos);
          cy.log(
-            "Find the cell in the 'connect-to-another-record-om' column, row 1"
+            "Find the cell in the 'connect-to-another-record-om' column, row 1",
          );
 
          cy.get(".webix_hcell")
@@ -72,7 +72,7 @@ export default () => {
                const omIndex = $column.attr("column");
 
                cy.get(
-                  `.webix_column[column="${omIndex}"] > [role="gridcell"][aria-rowindex="1"]`
+                  `.webix_column[column="${omIndex}"] > [role="gridcell"][aria-rowindex="1"]`,
                )
                   .should("exist")
                   .click({ force: true });
@@ -82,51 +82,54 @@ export default () => {
                   .contains("test-KCS-ID:0000000001")
                   .click();
                cy.get(
-                  `.webix_column[column="${omIndex}"] > [role="gridcell"][aria-rowindex="1"]`
+                  `.webix_column[column="${omIndex}"] > [role="gridcell"][aria-rowindex="1"]`,
                ).should("contain", "test-KCS-ID:0000000001");
             });
       });
       it("Sort a select list field", async () => {
          // click to open the sort popup
          cy.get(
-            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_buttonSort"]'
+            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_buttonSort"]',
          )
             .should("exist")
             .click();
 
          // click to show the Field option list
          cy.get(
-            '[view_id="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort"]'
+            '[view_id="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort"]',
          )
             .find('[view_id="sort_1"]')
-            .find('.webix_el_combo')
+            .find(".webix_el_combo")
             .should("exist")
             .click();
 
-
          // select the Field option item
-         cy.get(
-            '[webix_l_id="85ac56c3-17d5-48c0-abbb-850838b9a71d"]'
-         )
+         cy.get('[webix_l_id="85ac56c3-17d5-48c0-abbb-850838b9a71d"]')
             .should("exist")
             .click();
 
          // Reorder 'item2' to the top
          const win = await getWindow();
-         const $sortForm = win.$$("ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort_form");
+         const $sortForm = win.$$(
+            "ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort_form",
+         );
          const $orderList = $sortForm.queryView({ view: "list" });
          $orderList.moveTop("item2");
          $orderList.refresh();
 
          // Assert the order of options
-         cy.get('[view_id="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort_form"]')
-            .find('.webix_list')
-            .find('.webix_list_item')
+         cy.get(
+            '[view_id="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort_form"]',
+         )
+            .find(".webix_list")
+            .find(".webix_list_item")
             .first()
             .should("contain", "item2");
 
          // Assert data
-         cy.get('[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_datatable"]')
+         cy.get(
+            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_datatable"]',
+         )
             .find('[column="2"]')
             .find('[aria-rowindex="1"]')
             .should("contain", "text")
@@ -137,14 +140,18 @@ export default () => {
             });
 
          // Assert the order of options
-         cy.get('[view_id="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort_form"]')
-            .find('.webix_list')
-            .find('.webix_list_item')
+         cy.get(
+            '[view_id="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_table_popupSort_form"]',
+         )
+            .find(".webix_list")
+            .find(".webix_list_item")
             .first()
             .should("contain", "item1");
 
          // Assert
-         cy.get('[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_datatable"]')
+         cy.get(
+            '[data-cy="ABViewGrid_7aa0b5b1-8667-4293-ae9a-93e6639c4681_datatable"]',
+         )
             .find('[column="2"]')
             .find('[aria-rowindex="1"]')
             .should("contain", "text 2");

--- a/test_cases/widget_grid.js
+++ b/test_cases/widget_grid.js
@@ -28,9 +28,9 @@ export default () => {
             pos: 5300,
          };
          // Many Side
-         gridScroll(GRID, connect_mm.pos);
+         cy.GridScroll(GRID, connect_mm.pos);
          cy.log(
-            "Find the cell in the 'connect-to-another-record-mm' column, row 1"
+            "Find the cell in the 'connect-to-another-record-mm' column, row 1",
          );
 
          cy.get(".webix_hcell")
@@ -60,7 +60,7 @@ export default () => {
                   .and("contain", "test-KCS-ID:0000000002");
             });
          // One Side
-         gridScroll(GRID, connect_om.pos);
+         cy.GridScroll(GRID, connect_om.pos);
          cy.log(
             "Find the cell in the 'connect-to-another-record-om' column, row 1"
          );
@@ -158,11 +158,11 @@ export default () => {
  * @param {int} h horizontal scroll in pixels
  * @param {int=0} v veritcal scroll in pixels
  */
-function gridScroll(id, h, v = 0) {
-   cy.window().then((win) => {
-      return win.$$(id).scrollTo(h, v);
-   });
-}
+// function gridScroll(id, h, v = 0) {
+//    cy.window().then((win) => {
+//       return win.$$(id).scrollTo(h, v);
+//    });
+// }
 
 function getWindow() {
    return new Promise((resolve) => {

--- a/test_cases/widget_text.js
+++ b/test_cases/widget_text.js
@@ -2,16 +2,17 @@ export default () => {
    describe("Text", () => {
       it("Exists", () => {
          // Select the Text tab
-         cy.get(
-            '[data-cy^="tab-Text-"]'
-         )
+         cy.get('[data-cy^="tab-Text-"]')
             .scrollIntoView()
             .should("be.visible")
             .click();
          cy.get('[view_id^="ABViewText_"]')
             .find('[view_id$="_text"]')
             .should("be.visible")
-            .should("have.text", "longtext", { timeout: 50000, retryInterval: 500 });
+            .should("have.text", "longtext", {
+               timeout: 50000,
+               retryInterval: 500,
+            });
       });
    });
 };

--- a/test_setup/sql/add_testkcs.sql
+++ b/test_setup/sql/add_testkcs.sql
@@ -253,3 +253,9 @@ INSERT INTO `AB_kitchensink_testkcsForm2Link` (`uuid`, `created_at`, `updated_at
 VALUES
   ('b0ff1e8c-8257-4076-a5e9-dff84d6cfe6e','2024-04-22 22:16:43','2024-04-22 22:16:43',NULL,'Link1');
 UNLOCK TABLES;
+
+LOCK TABLES `AB_kitchensink_testkcsText` WRITE;
+INSERT INTO `AB_kitchensink_testkcsText` (`uuid`, `created_at`, `updated_at`, `properties`, `longtext`, `sort`)
+VALUES
+  (UUID(),NOW(),NOW(),NULL,'longtext',1);
+UNLOCK TABLES;

--- a/test_setup/sql/reset_tables.sql
+++ b/test_setup/sql/reset_tables.sql
@@ -72,4 +72,8 @@ LOCK TABLES `AB_kitchensink_testkcsForm2Link` WRITE;
 TRUNCATE TABLE `AB_kitchensink_testkcsForm2Link`;
 UNLOCK TABLES;
 
+LOCK TABLES `AB_kitchensink_testkcsText` WRITE;
+TRUNCATE TABLE `AB_kitchensink_testkcsText`;
+UNLOCK TABLES;
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
OK, this started off as simply making the Text tests truly isolated (using their own table).

Then additional changes in `ab_platform_web` cause the text box widgets to refresh, so cypress needs to be able to enter Text fields without delay.

Used .GridScroll() in the Datacollection tests as well.

Some additional bulletproofing of the cypress code.

## Release Notes
<!-- #release_notes -->
- [wip] refactor Text test to be truly isolated
- [wip] using new cy.GridScroll() command
- [fix] expected lengths
- [fix] text box refreshes can interrupt text entry, so make delay:0
- [fix] be sure to wait until progress loader is gone
- [add] additional check to ensure Form initialization is successful
- [add] eslint changes
<!-- /release_notes --> 

## Test Status
These are the new tests.  

changed Text Widget to be isolated from other tests. 

NOTE: requires [this PR](https://github.com/digi-serve/ab_runtime/pull/390)
